### PR TITLE
fix:SSL_connect rase no protocols available

### DIFF
--- a/lib/wework/api/methods/message.rb
+++ b/lib/wework/api/methods/message.rb
@@ -36,6 +36,14 @@ module Wework
           message_send user_ids, department_ids, {news: {articles: news}, msgtype: 'news'}
         end
 
+        def mpnews_message_send user_ids, department_ids, news=[]
+          message_send user_ids, department_ids, {mpnews: {articles: news}, msgtype: 'mpnews'}
+        end
+        
+        def markdown_message_send user_ids, department_ids, content
+          message_send user_ids, department_ids, {markdown: {content: content}, msgtype: 'markdown'}
+        end
+        
         private
 
         def message_send user_ids, department_ids, payload={}

--- a/lib/wework/request.rb
+++ b/lib/wework/request.rb
@@ -9,8 +9,10 @@ module Wework
     def initialize(base, skip_verify_ssl)
       @base = base
       @httprb = HTTP.timeout(**Wework.http_timeout_options)
-      @ssl_context = OpenSSL::SSL::SSLContext.new
-      @ssl_context.ssl_version = :TLSv1
+      @ssl_context = OpenSSL::SSL::SSLContext.new      
+      # ssl_version is deprecated and only provided for backwards compatibility. Use #min_version= and #max_version= instead
+      # @ssl_context.ssl_version = :TLSv1
+      @ssl_context.min_version = OpenSSL::SSL::TLS1_1_VERSION
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE if skip_verify_ssl
     end
 


### PR DESCRIPTION
ssl_version is deprecated and only provided for backwards compatibility. Use #min_version= and #max_version= instead